### PR TITLE
Clean useless "updatedAt" keys for create methods

### DIFF
--- a/test/branches.test.js
+++ b/test/branches.test.js
@@ -28,8 +28,7 @@ describe("Branch", function () {
 
         expect(newBranch).to.be.an("object").that.include.all.keys(
             "id",
-            "created_at",
-            "updated_at"
+            "created_at"
         );
     });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -40,8 +40,7 @@ describe("Nomad Client", function () {
         expect(newUser).to.be.an("object").to.include.all.keys(
             "id",
             "token",
-            "created_at",
-            "updated_at"
+            "created_at"
         );
 
         // remove the dummy user afterwards

--- a/test/media.test.js
+++ b/test/media.test.js
@@ -35,8 +35,7 @@ describe("Media", function () {
 
         expect(newMedia).to.be.an("object").that.include.all.keys(
             "id",
-            "created_at",
-            "updated_at"
+            "created_at"
         );
     });
 

--- a/test/roles.test.js
+++ b/test/roles.test.js
@@ -29,8 +29,7 @@ describe("Role", function () {
 
         expect(newRole).to.be.an("object").that.include.all.keys(
             "id",
-            "created_at",
-            "updated_at"
+            "created_at"
         );
     });
 

--- a/test/users.test.js
+++ b/test/users.test.js
@@ -31,8 +31,7 @@ describe("User", function () {
 
             expect(newUser).to.be.an("object").that.include.all.keys(
                 "id",
-                "created_at",
-                "updated_at"
+                "created_at"
             );
         });
 


### PR DESCRIPTION
### Purpose
There's no point in returning `updatedAt` with `create` methods

<!-- uncomment this section if it's relevant !
### Learning
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_
-->

### Checklist
<!-- Mark these as checked by replacing [ ] with [x] -->
- [ ] Configuration changes
- [ ] Added tests

<!-- To close resolved issues, add "Closes #ISSUE_NUMBER" -->

<!-- If this PR depends on a previous one, add "Depends on #PR_NUMBER" + select label `status:on-hold` -->
